### PR TITLE
Parser refactor

### DIFF
--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -254,7 +254,7 @@ struct BinaryExpression : Expression {
     void accept(Visitor& v) override { v.visit(this); }
 };
 
-struct Primary : Expression {
+struct Primary : Expression, Statement {
     lexer::Token value;
     bool operator==(const Primary& other) const {
         return Node::operator==(other) && value == other.value;
@@ -262,12 +262,13 @@ struct Primary : Expression {
     void accept(Visitor& v) override { v.visit(this); }
 };
 
-struct RoutineCall : Expression, Statement {
+struct RoutineCall : Primary {
     lexer::Token routine;
     std::vector<sPtr<Expression>> args;
 
     bool operator==(const RoutineCall& other) const {
-        return args == other.args && routine == other.routine;
+        return Node::operator==(other) && args == other.args &&
+               routine == other.routine;
     }
     void accept(Visitor& v) override { v.visit(this); }
 };

--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -15,6 +15,9 @@ struct TypeDecl;
 struct Type;
 struct AliasedType;
 struct PrimitiveType;
+struct IntegerType;
+struct RealType;
+struct BooleanType;
 struct ArrayType;
 struct RecordType;
 struct VariableDecl;
@@ -40,6 +43,9 @@ public:
     virtual void visit(Type* node) = 0;
     virtual void visit(TypeDecl* node) = 0;
     virtual void visit(PrimitiveType* node) = 0;
+    virtual void visit(IntegerType* node) = 0;
+    virtual void visit(RealType* node) = 0;
+    virtual void visit(BooleanType* node) = 0;
     virtual void visit(ArrayType* node) = 0;
     virtual void visit(RecordType* node) = 0;
     virtual void visit(VariableDecl* node) = 0;
@@ -129,10 +135,18 @@ struct AliasedType : Type {
 };
 
 struct PrimitiveType : Type {
-    lexer::TokenType type;
     bool operator==(const PrimitiveType& other) const {
-        return Node::operator==(other) && type == other.type;
+        return Node::operator==(other);
     }
+    virtual void accept(Visitor& v) override { v.visit(this); }
+};
+struct IntegerType : PrimitiveType {
+    void accept(Visitor& v) override { v.visit(this); }
+};
+struct RealType : PrimitiveType {
+    void accept(Visitor& v) override { v.visit(this); }
+};
+struct BooleanType : PrimitiveType {
     void accept(Visitor& v) override { v.visit(this); }
 };
 

--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -9,14 +9,14 @@ template <typename T> using sPtr = std::shared_ptr<T>;
 
 struct Node;
 struct Program;
-struct Routine;
+struct RoutineDecl;
 struct Parameter;
 struct Type;
 struct AliasedType;
 struct PrimitiveType;
 struct ArrayType;
 struct RecordType;
-struct Variable;
+struct VariableDecl;
 struct Body;
 struct Statement;
 struct Assignment;
@@ -33,13 +33,13 @@ class Visitor {
 public:
     virtual ~Visitor() = default;
     virtual void visit(Program* node) = 0;
-    virtual void visit(Routine* node) = 0;
+    virtual void visit(RoutineDecl* node) = 0;
     virtual void visit(Parameter* node) = 0;
     virtual void visit(Type* node) = 0;
     virtual void visit(PrimitiveType* node) = 0;
     virtual void visit(ArrayType* node) = 0;
     virtual void visit(RecordType* node) = 0;
-    virtual void visit(Variable* node) = 0;
+    virtual void visit(VariableDecl* node) = 0;
     virtual void visit(Body* node) = 0;
     virtual void visit(Statement* node) = 0;
     virtual void visit(Assignment* node) = 0;
@@ -67,8 +67,8 @@ struct Expression : virtual Node {
 };
 
 struct Program : Node {
-    std::vector<sPtr<Routine>> routines;
-    std::vector<sPtr<Variable>> variables;
+    std::vector<sPtr<RoutineDecl>> routines;
+    std::vector<sPtr<VariableDecl>> variables;
     std::vector<sPtr<Type>> types;
     bool operator==(const Program& other) const {
         return Node::operator==(other) && routines == other.routines &&
@@ -77,12 +77,12 @@ struct Program : Node {
     void accept(Visitor& v) override { v.visit(this); }
 };
 
-struct Routine : Node {
+struct RoutineDecl : Node {
     lexer::Token name;
     std::vector<sPtr<Parameter>> parameters;
     sPtr<Type> returnType;
     sPtr<Body> body;
-    bool operator==(const Routine& other) const {
+    bool operator==(const RoutineDecl& other) const {
         return Node::operator==(other) && name == other.name &&
                returnType == other.returnType && body == other.body &&
                parameters == other.parameters;
@@ -134,18 +134,18 @@ struct ArrayType : Type {
 };
 
 struct RecordType : Type {
-    std::vector<sPtr<Variable>> fields;
+    std::vector<sPtr<VariableDecl>> fields;
     bool operator==(const RecordType& other) const {
         return Node::operator==(other) && fields == other.fields;
     }
     void accept(Visitor& v) override { v.visit(this); }
 };
 
-struct Variable : Node {
+struct VariableDecl : Node {
     lexer::Token name;
     sPtr<Type> type;
     sPtr<Expression> expression;
-    bool operator==(const Variable& other) const {
+    bool operator==(const VariableDecl& other) const {
         return Node::operator==(other) && name == other.name &&
                type == other.type && expression == other.expression;
     }
@@ -154,7 +154,7 @@ struct Variable : Node {
 
 struct Body : Node {
     std::vector<sPtr<Statement>> statements;
-    std::vector<sPtr<Variable>> variables;
+    std::vector<sPtr<VariableDecl>> variables;
     std::vector<sPtr<Type>> types;
     bool operator==(const Body& other) const {
         return Node::operator==(other) && statements == other.statements &&

--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -11,6 +11,7 @@ struct Node;
 struct Program;
 struct RoutineDecl;
 struct Parameter;
+struct TypeDecl;
 struct Type;
 struct AliasedType;
 struct PrimitiveType;
@@ -37,6 +38,7 @@ public:
     virtual void visit(RoutineDecl* node) = 0;
     virtual void visit(Parameter* node) = 0;
     virtual void visit(Type* node) = 0;
+    virtual void visit(TypeDecl* node) = 0;
     virtual void visit(PrimitiveType* node) = 0;
     virtual void visit(ArrayType* node) = 0;
     virtual void visit(RecordType* node) = 0;
@@ -71,7 +73,7 @@ struct Expression : virtual Node {
 struct Program : Node {
     std::vector<sPtr<RoutineDecl>> routines;
     std::vector<sPtr<VariableDecl>> variables;
-    std::vector<sPtr<Type>> types;
+    std::vector<sPtr<TypeDecl>> types;
     bool operator==(const Program& other) const {
         return Node::operator==(other) && routines == other.routines &&
                variables == other.variables && types == other.types;
@@ -100,6 +102,15 @@ struct Parameter : Node {
                type == other.type;
     }
     void accept(Visitor& v) override { v.visit(this); }
+};
+
+struct TypeDecl : Node {
+    std::string name;
+    sPtr<Type> type;
+    bool operator==(const TypeDecl& other) const {
+        return Node::operator==(other) && name == other.name;
+    }
+    virtual void accept(Visitor& v) override { v.visit(this); }
 };
 
 struct Type : Node {
@@ -157,7 +168,7 @@ struct VariableDecl : Node {
 struct Body : Node {
     std::vector<sPtr<Statement>> statements;
     std::vector<sPtr<VariableDecl>> variables;
-    std::vector<sPtr<Type>> types;
+    std::vector<sPtr<TypeDecl>> types;
     bool operator==(const Body& other) const {
         return Node::operator==(other) && statements == other.statements &&
                variables == other.variables && types == other.types;

--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -223,7 +223,7 @@ struct ForLoop : Statement {
     std::string loopVar;
     sPtr<Expression> rangeFrom;
     sPtr<Expression> rangeTo;
-    bool reverse;
+    bool reverse = false;
     sPtr<Body> body;
     bool operator==(const ForLoop& other) const {
         return Node::operator==(other) && loopVar == other.loopVar &&
@@ -253,7 +253,7 @@ struct ReturnStatement : Statement {
 };
 
 struct Expression : virtual Node {
-    bool constant; // tells if this expression is a compile-time constant
+    bool constant = false; // tells if this expression is compile-time constant
     Type type;
     void accept(Visitor& v) override { v.visit(this); }
 };

--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -19,6 +19,7 @@ struct RecordType;
 struct VariableDecl;
 struct Body;
 struct Statement;
+struct ReturnStatement;
 struct Assignment;
 struct WhileLoop;
 struct ForLoop;
@@ -42,6 +43,7 @@ public:
     virtual void visit(VariableDecl* node) = 0;
     virtual void visit(Body* node) = 0;
     virtual void visit(Statement* node) = 0;
+    virtual void visit(ReturnStatement* node) = 0;
     virtual void visit(Assignment* node) = 0;
     virtual void visit(WhileLoop* node) = 0;
     virtual void visit(ForLoop* node) = 0;
@@ -206,6 +208,14 @@ struct IfStatement : Statement {
     bool operator==(const IfStatement& other) const {
         return Node::operator==(other) && condition == other.condition &&
                ifBody == other.ifBody && elseBody == other.elseBody;
+    }
+    void accept(Visitor& v) override { v.visit(this); }
+};
+
+struct ReturnStatement : Statement {
+    sPtr<Expression> expression;
+    bool operator==(const ReturnStatement& other) const {
+        return Node::operator==(other) && expression == other.expression;
     }
     void accept(Visitor& v) override { v.visit(this); }
 };

--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -32,6 +32,10 @@ struct Expression;
 struct UnaryExpression;
 struct BinaryExpression;
 struct Primary;
+struct IntegerLiteral;
+struct RealLiteral;
+struct BooleanLiteral;
+struct Identifier;
 struct RoutineCall;
 
 class Visitor {
@@ -58,6 +62,10 @@ public:
     virtual void visit(IfStatement* node) = 0;
     virtual void visit(Expression* node) = 0;
     virtual void visit(Primary* node) = 0;
+    virtual void visit(IntegerLiteral* node) = 0;
+    virtual void visit(RealLiteral* node) = 0;
+    virtual void visit(BooleanLiteral* node) = 0;
+    virtual void visit(Identifier* node) = 0;
     virtual void visit(RoutineCall* node) = 0;
     virtual void visit(UnaryExpression* node) = 0;
     virtual void visit(BinaryExpression* node) = 0;
@@ -140,12 +148,15 @@ struct PrimitiveType : Type {
     }
     virtual void accept(Visitor& v) override { v.visit(this); }
 };
+
 struct IntegerType : PrimitiveType {
     void accept(Visitor& v) override { v.visit(this); }
 };
+
 struct RealType : PrimitiveType {
     void accept(Visitor& v) override { v.visit(this); }
 };
+
 struct BooleanType : PrimitiveType {
     void accept(Visitor& v) override { v.visit(this); }
 };
@@ -269,9 +280,48 @@ struct BinaryExpression : Expression {
 };
 
 struct Primary : Expression, Statement {
-    lexer::TokenType value;
     bool operator==(const Primary& other) const {
-        return Node::operator==(other) && value == other.value;
+        return Node::operator==(other);
+    }
+    virtual void accept(Visitor& v) override { v.visit(this); }
+};
+
+struct IntegerLiteral : Primary {
+    long long value;
+    IntegerLiteral(long long value) : value(value) {}
+    bool operator==(const IntegerLiteral& other) const {
+        return Primary::operator==(other) && value == other.value;
+    }
+    void accept(Visitor& v) override { v.visit(this); }
+};
+
+struct RealLiteral : Primary {
+    double value;
+    RealLiteral(double value) : value(value) {}
+    bool operator==(const RealLiteral& other) const {
+        return Primary::operator==(other) && value == other.value;
+    }
+    void accept(Visitor& v) override { v.visit(this); }
+};
+
+struct BooleanLiteral : Primary {
+    bool value;
+    BooleanLiteral(bool value) : value(value) {}
+    bool operator==(const BooleanLiteral& other) const {
+        return Primary::operator==(other) && value == other.value;
+    }
+    void accept(Visitor& v) override { v.visit(this); }
+};
+
+// Used for holding variables. Can temporary hold unparenthesized routine calls
+//  until resolved.
+struct Identifier : Primary {
+    std::string name;
+    sPtr<VariableDecl> variable;
+    Identifier(std::string name) : name(name) {}
+    bool operator==(const Identifier& other) const {
+        return Primary::operator==(other) && name == other.name &&
+               variable == other.variable;
     }
     void accept(Visitor& v) override { v.visit(this); }
 };

--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -82,7 +82,7 @@ struct Program : Node {
 };
 
 struct RoutineDecl : Node {
-    lexer::Token name;
+    std::string name;
     std::vector<sPtr<Parameter>> parameters;
     sPtr<Type> returnType;
     sPtr<Body> body;
@@ -95,7 +95,7 @@ struct RoutineDecl : Node {
 };
 
 struct Parameter : Node {
-    lexer::Token name;
+    std::string name;
     sPtr<Type> type;
     bool operator==(const Parameter& other) const {
         return Node::operator==(other) && name == other.name &&
@@ -121,7 +121,7 @@ struct Type : Node {
  * To handle the "Identifier" kind of type
  */
 struct AliasedType : Type {
-    lexer::Token name;
+    std::string name;
     bool operator==(const AliasedType& other) const {
         return Node::operator==(other) && name == other.name;
     }
@@ -129,7 +129,7 @@ struct AliasedType : Type {
 };
 
 struct PrimitiveType : Type {
-    lexer::Token type;
+    lexer::TokenType type;
     bool operator==(const PrimitiveType& other) const {
         return Node::operator==(other) && type == other.type;
     }
@@ -155,7 +155,7 @@ struct RecordType : Type {
 };
 
 struct VariableDecl : Node {
-    lexer::Token name;
+    std::string name;
     sPtr<Type> type;
     sPtr<Expression> expression;
     bool operator==(const VariableDecl& other) const {
@@ -199,7 +199,7 @@ struct WhileLoop : Statement {
 };
 
 struct ForLoop : Statement {
-    lexer::Token loopVar;
+    std::string loopVar;
     sPtr<Expression> rangeFrom;
     sPtr<Expression> rangeTo;
     bool reverse;
@@ -233,7 +233,7 @@ struct ReturnStatement : Statement {
 
 struct UnaryExpression : Expression {
     sPtr<Expression> operand;
-    lexer::Token operation;
+    lexer::TokenType operation;
 
     bool operator==(const UnaryExpression& other) const {
         return Node::operator==(other) && operand == other.operand &&
@@ -245,7 +245,7 @@ struct UnaryExpression : Expression {
 struct BinaryExpression : Expression {
     sPtr<Expression> operand1;
     sPtr<Expression> operand2;
-    lexer::Token operation;
+    lexer::TokenType operation;
 
     bool operator==(const BinaryExpression& other) const {
         return Node::operator==(other) && operand1 == other.operand1 &&
@@ -255,7 +255,7 @@ struct BinaryExpression : Expression {
 };
 
 struct Primary : Expression, Statement {
-    lexer::Token value;
+    lexer::TokenType value;
     bool operator==(const Primary& other) const {
         return Node::operator==(other) && value == other.value;
     }
@@ -263,7 +263,8 @@ struct Primary : Expression, Statement {
 };
 
 struct RoutineCall : Primary {
-    lexer::Token routine;
+    sPtr<RoutineDecl> routine;
+    std::string routineName;
     std::vector<sPtr<Expression>> args;
 
     bool operator==(const RoutineCall& other) const {

--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -80,10 +80,6 @@ struct Node {
     virtual ~Node() = default;
 };
 
-struct Expression : virtual Node {
-    void accept(Visitor& v) override { v.visit(this); }
-};
-
 struct Program : Node {
     std::vector<sPtr<RoutineDecl>> routines;
     std::vector<sPtr<VariableDecl>> variables;
@@ -256,6 +252,12 @@ struct ReturnStatement : Statement {
     void accept(Visitor& v) override { v.visit(this); }
 };
 
+struct Expression : virtual Node {
+    bool constant; // tells if this expression is a compile-time constant
+    Type type;
+    void accept(Visitor& v) override { v.visit(this); }
+};
+
 struct UnaryExpression : Expression {
     sPtr<Expression> operand;
     lexer::TokenType operation;
@@ -288,7 +290,10 @@ struct Primary : Expression, Statement {
 
 struct IntegerLiteral : Primary {
     long long value;
-    IntegerLiteral(long long value) : value(value) {}
+    IntegerLiteral(long long value) : value(value) {
+        this->constant = true;
+        this->type = IntegerType();
+    }
     bool operator==(const IntegerLiteral& other) const {
         return Primary::operator==(other) && value == other.value;
     }
@@ -297,7 +302,10 @@ struct IntegerLiteral : Primary {
 
 struct RealLiteral : Primary {
     double value;
-    RealLiteral(double value) : value(value) {}
+    RealLiteral(double value) : value(value) {
+        this->constant = true;
+        this->type = RealType();
+    }
     bool operator==(const RealLiteral& other) const {
         return Primary::operator==(other) && value == other.value;
     }
@@ -306,7 +314,10 @@ struct RealLiteral : Primary {
 
 struct BooleanLiteral : Primary {
     bool value;
-    BooleanLiteral(bool value) : value(value) {}
+    BooleanLiteral(bool value) : value(value) {
+        this->constant = true;
+        this->type = BooleanType();
+    }
     bool operator==(const BooleanLiteral& other) const {
         return Primary::operator==(other) && value == other.value;
     }

--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -288,38 +288,38 @@ struct Primary : Expression, Statement {
     virtual void accept(Visitor& v) override { v.visit(this); }
 };
 
-struct IntegerLiteral : Primary {
+struct IntegerLiteral : Expression {
     long long value;
     IntegerLiteral(long long value) : value(value) {
         this->constant = true;
         this->type = IntegerType();
     }
     bool operator==(const IntegerLiteral& other) const {
-        return Primary::operator==(other) && value == other.value;
+        return Expression::operator==(other) && value == other.value;
     }
     void accept(Visitor& v) override { v.visit(this); }
 };
 
-struct RealLiteral : Primary {
+struct RealLiteral : Expression {
     double value;
     RealLiteral(double value) : value(value) {
         this->constant = true;
         this->type = RealType();
     }
     bool operator==(const RealLiteral& other) const {
-        return Primary::operator==(other) && value == other.value;
+        return Expression::operator==(other) && value == other.value;
     }
     void accept(Visitor& v) override { v.visit(this); }
 };
 
-struct BooleanLiteral : Primary {
+struct BooleanLiteral : Expression {
     bool value;
     BooleanLiteral(bool value) : value(value) {
         this->constant = true;
         this->type = BooleanType();
     }
     bool operator==(const BooleanLiteral& other) const {
-        return Primary::operator==(other) && value == other.value;
+        return Expression::operator==(other) && value == other.value;
     }
     void accept(Visitor& v) override { v.visit(this); }
 };

--- a/demo/lexer_demo.cpp
+++ b/demo/lexer_demo.cpp
@@ -18,7 +18,7 @@ std::vector<std::string> g_TokTypeStr{
     "Record",    "Array", "True",        "False",      "While",
     "For",       "Loop",  "End",         "Reverse,",   "In,",
     "If",        "Then",  "Else",        "Not",        "And",
-    "Or",        "Xor",
+    "Or",        "Xor",   "Return",
 };
 
 std::string to_string(lexer::TokenType type) {

--- a/demo/lexer_demo.cpp
+++ b/demo/lexer_demo.cpp
@@ -7,28 +7,11 @@
 #include <iostream>
 #include <iterator>
 
-std::vector<std::string> g_TokTypeStr{
-    "Illegal",   "Eof",   "Comment",     "Identifier", "Int",
-    "Real",      "Less",  "Greater",     "Eq",         "Leq",
-    "Geq",       "Neq",   "Assign",      "Add",        "Sub",
-    "Mul",       "Div",   "Mod",         "OpenParen",  "OpenBrack",
-    "Comma",     "Dot",   "TwoDots",     "CloseParen", "CloseBrack",
-    "Semicolon", "Colon", "NewLine",     "Var",        "Type",
-    "Routine",   "Is",    "IntegerType", "RealType",   "Boolean",
-    "Record",    "Array", "True",        "False",      "While",
-    "For",       "Loop",  "End",         "Reverse,",   "In,",
-    "If",        "Then",  "Else",        "Not",        "And",
-    "Or",        "Xor",   "Return",
-};
-
-std::string to_string(lexer::TokenType type) {
-    return g_TokTypeStr[static_cast<int>(type)];
-}
 
 void printTokens(const std::vector<lexer::Token>& toks) {
     for (auto& tok : toks) {
         auto str = common::replaceAll(tok.lit, "\n", "\\n");
-        fmt::print("{} ({}) ", str, to_string(tok.type));
+        fmt::print("{} ({}) ", str, lexer::to_string(tok.type));
     }
     fmt::print("\n\n");
 }

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -310,6 +310,38 @@ int main(int argc, char* argv[]) {
     }
 
     for (;;) {
+        int choice;
+        typedef parser::sPtr<ast::Node> (parser::Parser::*ParserFunc)();
+        ParserFunc parseFunc;
+        fmt::print("What do you want to parse?\n");
+        fmt::print("(0) Exit\n");
+        fmt::print("(1) routine\n");
+        fmt::print("(2) expression\n");
+        fmt::print("(3) type declaration\n");
+        fmt::print("(4) statement\n");
+        fmt::print("Enter a number> ");
+        std::cin >> choice;
+        std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+        switch (choice) {
+        case 0:
+            return 0;
+        case 1:
+            parseFunc = (ParserFunc)(&parser::Parser::parseRoutineDecl);
+            break;
+        case 2:
+            parseFunc = (ParserFunc)(&parser::Parser::parseExpression);
+            break;
+        case 3:
+            parseFunc = (ParserFunc)(&parser::Parser::parseTypeDecl);
+            break;
+        case 4:
+            parseFunc = (ParserFunc)(&parser::Parser::parseStatement);
+            break;
+        default:
+            fmt::print("Invalid option\n");
+            return 1;
+        }
+
         fmt::print("riddle> ");
         std::string line;
         std::getline(std::cin, line);
@@ -317,7 +349,7 @@ int main(int argc, char* argv[]) {
         lexer::Lexer lx{line};
         parser::Parser parser(lx);
 
-        auto ast = parser.parseExpression();
+        auto ast = (parser.*parseFunc)();
         auto errors = parser.getErrors();
         if (errors.empty()) {
             PrintVisitor v;
@@ -331,6 +363,7 @@ int main(int argc, char* argv[]) {
                            error.message);
             }
         }
+        fmt::print("\n");
     }
 
     return 0;

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -9,9 +9,37 @@
 class PrintVisitor : public ast::Visitor {
 public:
     PrintVisitor(size_t depth = 0) : depth(depth) {}
-    void visit(ast::Program* node) override {}
-    void visit(ast::RoutineDecl* node) override{
-
+    void visit(ast::Program* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [Program]> null\n", "", depth);
+            return;
+        }
+        fmt::print("{:|>{}}- [Program]>\n", "", depth);
+        depth++;
+        for (auto type : node->types) {
+            type->accept(*this);
+        }
+        for (auto routine : node->routines) {
+            routine->accept(*this);
+        }
+        for (auto variableDecl : node->variables) {
+            variableDecl->accept(*this);
+        }
+        depth--;
+    }
+    void visit(ast::RoutineDecl* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [RoutineDecl]> null\n", "", depth);
+            return;
+        }
+        fmt::print("{:|>{}}- [RoutineDecl]> {}\n", "", depth, node->name.lit);
+        depth++;
+        for (auto parameter : node->parameters) {
+            parameter->accept(*this);
+        }
+        node->body->accept(*this);
+        node->returnType->accept(*this);
+        depth--;
     };
     void visit(ast::Parameter* node) override {
         if (node == nullptr) {
@@ -93,14 +121,39 @@ public:
             depth--;
         }
     };
-    void visit(ast::Body* node) override{
-
+    void visit(ast::Body* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [Body]> null\n", "", depth);
+            return;
+        }
+        depth++;
+        for (auto type : node->types) {
+            type->accept(*this);
+        }
+        for (auto variableDecl : node->variables) {
+            variableDecl->accept(*this);
+        }
+        for (auto statement : node->statements) {
+            statement->accept(*this);
+        }
+        depth--;
     };
-    void visit(ast::Statement* node) override{
-
-    };
-    void visit(ast::Assignment* node) override{
-
+    void visit(ast::Statement* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [Statement]> null\n", "", depth);
+            return;
+        }
+        fmt::print("{:|>{}}- [Statement]>\n", "", depth);
+        };
+    void visit(ast::Assignment* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [Assignment]> null\n", "", depth);
+            return;
+        }
+        depth++;
+        node->lhs->accept(*this);
+        node->rhs->accept(*this);
+        depth--;
     };
     void visit(ast::WhileLoop* node) override {
         if (node == nullptr) {
@@ -140,8 +193,12 @@ public:
             depth--;
         }
     };
-    void visit(ast::Expression* node) override{
-
+    void visit(ast::Expression* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [Expression]> null\n", "", depth);
+            return;
+        }
+        fmt::print("{:|>{}}- [Expression]>\n", "", depth);
     };
     void visit(ast::UnaryExpression* node) override {
         if (node == nullptr) {
@@ -180,7 +237,7 @@ public:
             fmt::print("{:|>{}}- [RoutineCall]> {}\n", "", depth,
                        node->routine.lit);
             depth++;
-            for (int i = 0; i < node->args.size(); i++) {
+            for (size_t i = 0; i < node->args.size(); i++) {
                 node->args[i]->accept(*this);
             }
             depth--;

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -8,6 +8,18 @@
 #include "lexer.hpp"
 #include "parser.hpp"
 
+std::unordered_map<lexer::TokenType, std::string> op_to_string{
+    {lexer::TokenType::Add, "+"},     {lexer::TokenType::Sub, "-"},
+    {lexer::TokenType::Mul, "*"},     {lexer::TokenType::Div, "/"},
+    {lexer::TokenType::Mod, "%"},     {lexer::TokenType::Or, "or"},
+    {lexer::TokenType::Xor, "xor"},   {lexer::TokenType::And, "and"},
+    {lexer::TokenType::Eq, "="},      {lexer::TokenType::Neq, "/="},
+    {lexer::TokenType::Less, "<"},    {lexer::TokenType::Leq, "<="},
+    {lexer::TokenType::Greater, ">"}, {lexer::TokenType::Geq, ">="},
+    {lexer::TokenType::Not, "not"},   {lexer::TokenType::OpenParen, "()"},
+    {lexer::TokenType::Dot, "."},     {lexer::TokenType::OpenBrack, "[]"},
+};
+
 class PrintVisitor : public ast::Visitor {
 public:
     PrintVisitor(size_t depth = 0) : depth(depth) {}
@@ -82,7 +94,28 @@ public:
             fmt::print("{:|>{}}- [PrimitiveType]> null\n", "", depth);
             return;
         }
-        fmt::print("{:|>{}}- [PrimitiveType]> {}\n", "", depth, node->type);
+        fmt::print("{:|>{}}- [PrimitiveType]> unknown\n", "", depth);
+    }
+    void visit(ast::IntegerType* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [IntegerType]> null\n", "", depth);
+            return;
+        }
+        fmt::print("{:|>{}}- [IntegerType]\n", "", depth);
+    }
+    void visit(ast::RealType* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [RealType]> null\n", "", depth);
+            return;
+        }
+        fmt::print("{:|>{}}- [RealType]\n", "", depth);
+    }
+    void visit(ast::BooleanType* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [BooleanType]> null\n", "", depth);
+            return;
+        }
+        fmt::print("{:|>{}}- [BooleanType]\n", "", depth);
     }
     void visit(ast::ArrayType* node) override {
         if (node == nullptr) {
@@ -235,7 +268,7 @@ public:
             return;
         }
         fmt::print("{:|>{}}- [UnaryExpression]> {}\n", "", depth,
-                   node->operation);
+                   op_to_string[node->operation]);
         depth++;
         node->operand->accept(*this);
         depth--;
@@ -246,7 +279,7 @@ public:
             return;
         }
         fmt::print("{:|>{}}- [BinaryExpression]> {}\n", "", depth,
-                   node->operation);
+                   op_to_string[node->operation]);
         depth++;
         node->operand1->accept(*this);
         node->operand2->accept(*this);

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -117,6 +117,9 @@ public:
         if (node->type != nullptr) {
             node->type->accept(*this);
         }
+        if (node->expression != nullptr) {
+            node->expression->accept(*this);
+        }
         depth--;
     }
     void visit(ast::TypeDecl* node) override {

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -33,11 +33,11 @@ public:
         for (auto type : node->types) {
             type->accept(*this);
         }
-        for (auto routine : node->routines) {
-            routine->accept(*this);
-        }
         for (auto variableDecl : node->variables) {
             variableDecl->accept(*this);
+        }
+        for (auto routine : node->routines) {
+            routine->accept(*this);
         }
         depth--;
     }

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -119,6 +119,17 @@ public:
         }
         depth--;
     }
+    void visit(ast::TypeDecl* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [TypeDecl]> null\n", "", depth);
+        }
+        fmt::print("{:|>{}}- [TypeDecl]> {}\n", "", depth, node->name);
+        depth++;
+        if (node->type != nullptr) {
+            node->type->accept(*this);
+        }
+        depth--;
+    }
     void visit(ast::Body* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [Body]> null\n", "", depth);

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -298,9 +298,9 @@ int main(int argc, char* argv[]) {
                        "Parsing Errors:\n");
             for (auto error : errors) {
                 fmt::print("*\t{}\n", lines[error.pos.line - 1]);
-                fmt::print("\t{:->{}}^{:-<{}}\n", "", error.pos.column, "",
+                fmt::print("\t{:->{}}^{:-<{}}\n", "", error.pos.column - 1, "",
                            lines[error.pos.line - 1].length() -
-                               error.pos.column - 1 - 1);
+                               error.pos.column - 1);
                 fmt::print(fg(fmt::color::indian_red),
                            "\t[line: {}, column: {}]: {}\n\n", error.pos.line,
                            error.pos.column, error.message);

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -1,7 +1,7 @@
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <sstream>
-#include <functional>
 
 #include "fmt/color.h"
 #include "fmt/core.h"
@@ -34,7 +34,7 @@ public:
             fmt::print("{:|>{}}- [RoutineDecl]> null\n", "", depth);
             return;
         }
-        fmt::print("{:|>{}}- [RoutineDecl]> {}\n", "", depth, node->name.lit);
+        fmt::print("{:|>{}}- [RoutineDecl]> {}\n", "", depth, node->name);
         depth++;
         for (auto parameter : node->parameters) {
             parameter->accept(*this);
@@ -50,7 +50,7 @@ public:
             fmt::print("{:|>{}}- [Parameter]> null\n", "", depth);
             return;
         }
-        fmt::print("{:|>{}}- [Parameter]> {}\n", "", depth, node->name.lit);
+        fmt::print("{:|>{}}- [Parameter]> {}\n", "", depth, node->name);
         depth++;
         node->type->accept(*this);
         depth--;
@@ -72,7 +72,7 @@ public:
                        dynamic_cast<ast::AliasedType*>(node);
                    specific != nullptr) {
             fmt::print("{:|>{}}- [Type Identifier]> {}\n", "", depth,
-                       specific->name.lit);
+                       specific->name);
         } else {
             fmt::print("{:|>{}}- [Type]> (unknown type)\n", "", depth);
         }
@@ -82,7 +82,7 @@ public:
             fmt::print("{:|>{}}- [PrimitiveType]> null\n", "", depth);
             return;
         }
-        fmt::print("{:|>{}}- [PrimitiveType]> {}\n", "", depth, node->type.lit);
+        fmt::print("{:|>{}}- [PrimitiveType]> {}\n", "", depth, node->type);
     }
     void visit(ast::ArrayType* node) override {
         if (node == nullptr) {
@@ -115,7 +115,7 @@ public:
         if (node == nullptr) {
             fmt::print("{:|>{}}- [VariableDecl]> null\n", "", depth);
         }
-        fmt::print("{:|>{}}- [VariableDecl]> {}\n", "", depth, node->name.lit);
+        fmt::print("{:|>{}}- [VariableDecl]> {}\n", "", depth, node->name);
         depth++;
         if (node->type != nullptr) {
             node->type->accept(*this);
@@ -235,7 +235,7 @@ public:
             return;
         }
         fmt::print("{:|>{}}- [UnaryExpression]> {}\n", "", depth,
-                   node->operation.lit);
+                   node->operation);
         depth++;
         node->operand->accept(*this);
         depth--;
@@ -246,7 +246,7 @@ public:
             return;
         }
         fmt::print("{:|>{}}- [BinaryExpression]> {}\n", "", depth,
-                   node->operation.lit);
+                   node->operation);
         depth++;
         node->operand1->accept(*this);
         node->operand2->accept(*this);
@@ -257,7 +257,7 @@ public:
             fmt::print("{:|>{}}- [Primary]> null\n", "", depth);
             return;
         }
-        fmt::print("{:|>{}}- [Primary]> {}\n", "", depth, node->value.lit);
+        fmt::print("{:|>{}}- [Primary]> {}\n", "", depth, node->value);
     }
     void visit(ast::RoutineCall* node) override {
         if (node == nullptr) {
@@ -265,7 +265,7 @@ public:
             return;
         }
         fmt::print("{:|>{}}- [RoutineCall]> {}\n", "", depth,
-                   node->routine.lit);
+                   node->routineName);
         depth++;
         for (size_t i = 0; i < node->args.size(); i++) {
             node->args[i]->accept(*this);

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -321,7 +321,6 @@ int main(int argc, char* argv[]) {
         fmt::print("(4) statement\n");
         fmt::print("Enter a number> ");
         std::cin >> choice;
-        std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         switch (choice) {
         case 0:
             return 0;
@@ -344,7 +343,7 @@ int main(int argc, char* argv[]) {
 
         fmt::print("riddle> ");
         std::string line;
-        std::getline(std::cin, line);
+        std::getline(std::cin >> std::ws, line);
 
         lexer::Lexer lx{line};
         parser::Parser parser(lx);

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -290,7 +290,35 @@ public:
             fmt::print("{:|>{}}- [Primary]> null\n", "", depth);
             return;
         }
-        fmt::print("{:|>{}}- [Primary]> {}\n", "", depth, node->value);
+        fmt::print("{:|>{}}- [Primary]> unknown\n", "", depth);
+    }
+    void visit(ast::IntegerLiteral* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [IntegerLiteral]> null\n", "", depth);
+            return;
+        }
+        fmt::print("{:|>{}}- [IntegerLiteral]> {}\n", "", depth, node->value);
+    }
+    void visit(ast::RealLiteral* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [RealLiteral]> null\n", "", depth);
+            return;
+        }
+        fmt::print("{:|>{}}- [RealLiteral]> {}\n", "", depth, node->value);
+    }
+    void visit(ast::BooleanLiteral* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [BooleanLiteral]> null\n", "", depth);
+            return;
+        }
+        fmt::print("{:|>{}}- [BooleanLiteral]> {}\n", "", depth, node->value);
+    }
+    void visit(ast::Identifier* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [Identifier]> null\n", "", depth);
+            return;
+        }
+        fmt::print("{:|>{}}- [Identifier]> {}\n", "", depth, node->name);
     }
     void visit(ast::RoutineCall* node) override {
         if (node == nullptr) {

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -41,7 +41,7 @@ public:
         node->body->accept(*this);
         node->returnType->accept(*this);
         depth--;
-    };
+    }
     void visit(ast::Parameter* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [Parameter]> null\n", "", depth);
@@ -51,7 +51,7 @@ public:
             node->type->accept(*this);
             depth--;
         }
-    };
+    }
     void visit(ast::Type* node) override {
         if (ast::PrimitiveType* specific =
                 dynamic_cast<ast::PrimitiveType*>(node);
@@ -73,7 +73,7 @@ public:
         } else {
             fmt::print("{:|>{}}- [Type]> (unknown type)\n", "", depth);
         }
-    };
+    }
     void visit(ast::PrimitiveType* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [PrimitiveType]> null\n", "", depth);
@@ -81,7 +81,7 @@ public:
             fmt::print("{:|>{}}- [PrimitiveType]> {}\n", "", depth,
                        node->type.lit);
         }
-    };
+    }
     void visit(ast::ArrayType* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [ArrayType]> null\n", "", depth);
@@ -96,7 +96,7 @@ public:
             }
             depth--;
         }
-    };
+    }
     void visit(ast::RecordType* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [RecordType]> null\n", "", depth);
@@ -108,7 +108,7 @@ public:
             }
             depth--;
         }
-    };
+    }
     void visit(ast::VariableDecl* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [VariableDecl]> null\n", "", depth);
@@ -121,12 +121,13 @@ public:
             }
             depth--;
         }
-    };
+    }
     void visit(ast::Body* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [Body]> null\n", "", depth);
             return;
         }
+        fmt::print("{:|>{}}- [Body]>\n", "", depth);
         depth++;
         for (auto type : node->types) {
             type->accept(*this);
@@ -138,14 +139,26 @@ public:
             statement->accept(*this);
         }
         depth--;
-    };
+    }
     void visit(ast::Statement* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [Statement]> null\n", "", depth);
             return;
         }
-        fmt::print("{:|>{}}- [Statement]>\n", "", depth);
-        };
+        fmt::print("{:|>{}}- [Statement]> Unknown\n", "", depth);
+    }
+    void visit(ast::ReturnStatement* node) override {
+        if (node == nullptr) {
+            fmt::print("{:|>{}}- [Return]> null\n", "", depth);
+            return;
+        }
+        fmt::print("{:|>{}}- [Return]>\n", "", depth);
+        depth++;
+        if (node->expression != nullptr) {
+            node->expression->accept(*this);
+        }
+        depth--;
+    }
     void visit(ast::Assignment* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [Assignment]> null\n", "", depth);
@@ -155,7 +168,7 @@ public:
         node->lhs->accept(*this);
         node->rhs->accept(*this);
         depth--;
-    };
+    }
     void visit(ast::WhileLoop* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [WhileLoop]> null\n", "", depth);
@@ -166,7 +179,7 @@ public:
             node->body->accept(*this);
             depth--;
         }
-    };
+    }
     void visit(ast::ForLoop* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [ForLoop]> null\n", "", depth);
@@ -179,7 +192,7 @@ public:
             node->body->accept(*this);
             depth--;
         }
-    };
+    }
     void visit(ast::IfStatement* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [IfStatement]> null\n", "", depth);
@@ -193,14 +206,14 @@ public:
             }
             depth--;
         }
-    };
+    }
     void visit(ast::Expression* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [Expression]> null\n", "", depth);
             return;
         }
         fmt::print("{:|>{}}- [Expression]>\n", "", depth);
-    };
+    }
     void visit(ast::UnaryExpression* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [UnaryExpression]> null\n", "", depth);
@@ -211,7 +224,7 @@ public:
             node->operand->accept(*this);
             depth--;
         }
-    };
+    }
     void visit(ast::BinaryExpression* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [BinaryExpression]> null\n", "", depth);
@@ -223,14 +236,14 @@ public:
             node->operand2->accept(*this);
             depth--;
         }
-    };
+    }
     void visit(ast::Primary* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [Primary]> null\n", "", depth);
         } else {
             fmt::print("{:|>{}}- [Primary]> {}\n", "", depth, node->value.lit);
         }
-    };
+    }
     void visit(ast::RoutineCall* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [RoutineCall]> null\n", "", depth);
@@ -243,7 +256,7 @@ public:
             }
             depth--;
         }
-    };
+    }
 
 private:
     size_t depth;

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -1,6 +1,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <functional>
 
 #include "fmt/color.h"
 #include "fmt/core.h"
@@ -318,8 +319,7 @@ int main(int argc, char* argv[]) {
 
     for (;;) {
         int choice;
-        typedef parser::sPtr<ast::Node> (parser::Parser::*ParserFunc)();
-        ParserFunc parseFunc;
+        std::function<std::shared_ptr<ast::Node>(parser::Parser&)> parseFunc;
         fmt::print("What do you want to parse?\n");
         fmt::print("(0) Exit\n");
         fmt::print("(1) routine\n");
@@ -332,16 +332,16 @@ int main(int argc, char* argv[]) {
         case 0:
             return 0;
         case 1:
-            parseFunc = (ParserFunc)(&parser::Parser::parseRoutineDecl);
+            parseFunc = [](parser::Parser& p) { return p.parseRoutineDecl(); };
             break;
         case 2:
-            parseFunc = (ParserFunc)(&parser::Parser::parseExpression);
+            parseFunc = [](parser::Parser& p) { return p.parseExpression(); };
             break;
         case 3:
-            parseFunc = (ParserFunc)(&parser::Parser::parseTypeDecl);
+            parseFunc = [](parser::Parser& p) { return p.parseTypeDecl(); };
             break;
         case 4:
-            parseFunc = (ParserFunc)(&parser::Parser::parseStatement);
+            parseFunc = [](parser::Parser& p) { return p.parseStatement(); };
             break;
         default:
             fmt::print("Invalid option\n");
@@ -355,7 +355,7 @@ int main(int argc, char* argv[]) {
         lexer::Lexer lx{line};
         parser::Parser parser(lx);
 
-        auto ast = (parser.*parseFunc)();
+        auto ast = parseFunc(parser);
         auto errors = parser.getErrors();
         if (errors.empty()) {
             PrintVisitor v;

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -311,6 +311,7 @@ int main(int argc, char* argv[]) {
                            "\t[line: {}, column: {}]: {}\n\n", error.pos.line,
                            error.pos.column, error.message);
             }
+            return 1;
         }
         return 0;
     }

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -45,12 +45,12 @@ public:
     void visit(ast::Parameter* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [Parameter]> null\n", "", depth);
-        } else {
-            fmt::print("{:|>{}}- [Parameter]> {}\n", "", depth, node->name.lit);
-            depth++;
-            node->type->accept(*this);
-            depth--;
+            return;
         }
+        fmt::print("{:|>{}}- [Parameter]> {}\n", "", depth, node->name.lit);
+        depth++;
+        node->type->accept(*this);
+        depth--;
     }
     void visit(ast::Type* node) override {
         if (ast::PrimitiveType* specific =
@@ -77,50 +77,47 @@ public:
     void visit(ast::PrimitiveType* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [PrimitiveType]> null\n", "", depth);
-        } else {
-            fmt::print("{:|>{}}- [PrimitiveType]> {}\n", "", depth,
-                       node->type.lit);
+            return;
         }
+        fmt::print("{:|>{}}- [PrimitiveType]> {}\n", "", depth, node->type.lit);
     }
     void visit(ast::ArrayType* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [ArrayType]> null\n", "", depth);
-        } else {
-            fmt::print("{:|>{}}- [ArrayType]>\n", "", depth);
-            depth++;
-            if (node->length != nullptr) {
-                node->length->accept(*this);
-            }
-            if (node->elementType != nullptr) {
-                node->elementType->accept(*this);
-            }
-            depth--;
+            return;
         }
+        fmt::print("{:|>{}}- [ArrayType]>\n", "", depth);
+        depth++;
+        if (node->length != nullptr) {
+            node->length->accept(*this);
+        }
+        if (node->elementType != nullptr) {
+            node->elementType->accept(*this);
+        }
+        depth--;
     }
     void visit(ast::RecordType* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [RecordType]> null\n", "", depth);
-        } else {
-            fmt::print("{:|>{}}- [RecordType]>\n", "", depth);
-            depth++;
-            for (auto field : node->fields) {
-                field->accept(*this);
-            }
-            depth--;
+            return;
         }
+        fmt::print("{:|>{}}- [RecordType]>\n", "", depth);
+        depth++;
+        for (auto field : node->fields) {
+            field->accept(*this);
+        }
+        depth--;
     }
     void visit(ast::VariableDecl* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [VariableDecl]> null\n", "", depth);
-        } else {
-            fmt::print("{:|>{}}- [VariableDecl]> {}\n", "", depth,
-                       node->name.lit);
-            depth++;
-            if (node->type != nullptr) {
-                node->type->accept(*this);
-            }
-            depth--;
         }
+        fmt::print("{:|>{}}- [VariableDecl]> {}\n", "", depth, node->name.lit);
+        depth++;
+        if (node->type != nullptr) {
+            node->type->accept(*this);
+        }
+        depth--;
     }
     void visit(ast::Body* node) override {
         if (node == nullptr) {
@@ -172,40 +169,40 @@ public:
     void visit(ast::WhileLoop* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [WhileLoop]> null\n", "", depth);
-        } else {
-            fmt::print("{:|>{}}- [WhileLoop]>\n", "", depth);
-            depth++;
-            node->condition->accept(*this);
-            node->body->accept(*this);
-            depth--;
+            return;
         }
+        fmt::print("{:|>{}}- [WhileLoop]>\n", "", depth);
+        depth++;
+        node->condition->accept(*this);
+        node->body->accept(*this);
+        depth--;
     }
     void visit(ast::ForLoop* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [ForLoop]> null\n", "", depth);
-        } else {
-            fmt::print("{:|>{}}- [ForLoop]>\n", "", depth);
-            depth++;
-            // node->loopVar->accept(*this);
-            node->rangeFrom->accept(*this);
-            node->rangeTo->accept(*this);
-            node->body->accept(*this);
-            depth--;
+            return;
         }
+        fmt::print("{:|>{}}- [ForLoop]>\n", "", depth);
+        depth++;
+        // node->loopVar->accept(*this);
+        node->rangeFrom->accept(*this);
+        node->rangeTo->accept(*this);
+        node->body->accept(*this);
+        depth--;
     }
     void visit(ast::IfStatement* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [IfStatement]> null\n", "", depth);
-        } else {
-            fmt::print("{:|>{}}- [IfStatement]>\n", "", depth);
-            depth++;
-            node->condition->accept(*this);
-            node->ifBody->accept(*this);
-            if (node->elseBody) {
-                node->elseBody->accept(*this);
-            }
-            depth--;
+            return;
         }
+        fmt::print("{:|>{}}- [IfStatement]>\n", "", depth);
+        depth++;
+        node->condition->accept(*this);
+        node->ifBody->accept(*this);
+        if (node->elseBody) {
+            node->elseBody->accept(*this);
+        }
+        depth--;
     }
     void visit(ast::Expression* node) override {
         if (node == nullptr) {
@@ -217,45 +214,45 @@ public:
     void visit(ast::UnaryExpression* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [UnaryExpression]> null\n", "", depth);
-        } else {
-            fmt::print("{:|>{}}- [UnaryExpression]> {}\n", "", depth,
-                       node->operation.lit);
-            depth++;
-            node->operand->accept(*this);
-            depth--;
+            return;
         }
+        fmt::print("{:|>{}}- [UnaryExpression]> {}\n", "", depth,
+                   node->operation.lit);
+        depth++;
+        node->operand->accept(*this);
+        depth--;
     }
     void visit(ast::BinaryExpression* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [BinaryExpression]> null\n", "", depth);
-        } else {
-            fmt::print("{:|>{}}- [BinaryExpression]> {}\n", "", depth,
-                       node->operation.lit);
-            depth++;
-            node->operand1->accept(*this);
-            node->operand2->accept(*this);
-            depth--;
+            return;
         }
+        fmt::print("{:|>{}}- [BinaryExpression]> {}\n", "", depth,
+                   node->operation.lit);
+        depth++;
+        node->operand1->accept(*this);
+        node->operand2->accept(*this);
+        depth--;
     }
     void visit(ast::Primary* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [Primary]> null\n", "", depth);
-        } else {
-            fmt::print("{:|>{}}- [Primary]> {}\n", "", depth, node->value.lit);
+            return;
         }
+        fmt::print("{:|>{}}- [Primary]> {}\n", "", depth, node->value.lit);
     }
     void visit(ast::RoutineCall* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [RoutineCall]> null\n", "", depth);
-        } else {
-            fmt::print("{:|>{}}- [RoutineCall]> {}\n", "", depth,
-                       node->routine.lit);
-            depth++;
-            for (size_t i = 0; i < node->args.size(); i++) {
-                node->args[i]->accept(*this);
-            }
-            depth--;
+            return;
         }
+        fmt::print("{:|>{}}- [RoutineCall]> {}\n", "", depth,
+                   node->routine.lit);
+        depth++;
+        for (size_t i = 0; i < node->args.size(); i++) {
+            node->args[i]->accept(*this);
+        }
+        depth--;
     }
 
 private:

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -39,7 +39,9 @@ public:
             parameter->accept(*this);
         }
         node->body->accept(*this);
-        node->returnType->accept(*this);
+        if (node->returnType != nullptr) {
+            node->returnType->accept(*this);
+        }
         depth--;
     }
     void visit(ast::Parameter* node) override {
@@ -175,6 +177,7 @@ public:
             fmt::print("{:|>{}}- [Assignment]> null\n", "", depth);
             return;
         }
+        fmt::print("{:|>{}}- [Assignment]>\n", "", depth);
         depth++;
         node->lhs->accept(*this);
         node->rhs->accept(*this);

--- a/demo/parser_demo.cpp
+++ b/demo/parser_demo.cpp
@@ -10,7 +10,7 @@ class PrintVisitor : public ast::Visitor {
 public:
     PrintVisitor(size_t depth = 0) : depth(depth) {}
     void visit(ast::Program* node) override {}
-    void visit(ast::Routine* node) override{
+    void visit(ast::RoutineDecl* node) override{
 
     };
     void visit(ast::Parameter* node) override {
@@ -80,7 +80,7 @@ public:
             depth--;
         }
     };
-    void visit(ast::Variable* node) override {
+    void visit(ast::VariableDecl* node) override {
         if (node == nullptr) {
             fmt::print("{:|>{}}- [VariableDecl]> null\n", "", depth);
         } else {

--- a/examples/ex6.rdd
+++ b/examples/ex6.rdd
@@ -33,8 +33,7 @@ routine dijkstra(graph: array array integer, src: integer): // We accept such de
             // u to v, and total weight of path from src to  v through u is 
             // smaller than current value of dist[v]
             // NOTE: no `not` in grammar
-            if not sptSet[v] and graph[u][v] /= -1 and dist[u] /= INFINITY 
-               and dist[u] + graph[u][v] < dist[v] then
+            if not sptSet[v] and graph[u][v] /= -1 and dist[u] /= INFINITY and dist[u] + graph[u][v] < dist[v] then
                dist[v] := dist[u] + graph[u][v]
            end
         end
@@ -43,7 +42,7 @@ routine dijkstra(graph: array array integer, src: integer): // We accept such de
 end
 
 routine main () is
-    var graph is array [3] array [3] integer
+    var graph : array [3] array [3] integer
     graph[1][1] := 3; graph[1][2] := 1; graph[1][3] := 2
     graph[2][1] := 5; graph[2][2] := 4; graph[3][3] := 6
     graph[3][1] := 1; graph[3][2] := 4; graph[3][3] := 9

--- a/lexer/impl/lexer.cpp
+++ b/lexer/impl/lexer.cpp
@@ -83,12 +83,10 @@ char Lexer::peek(size_t offset) {
  * Returns the next token without consuming it.
  */
 Token Lexer::Peek() {
-    if (currentToken == nullptr) {
-        currentToken = std::make_shared<Token>(scanNext());
-    } else if (currentToken->type == TokenType::Eof) {
-        throw "End-of-file already reached";
+    if (consumedEof) {
+        throw std::overflow_error("End-of-file already consumed");
     }
-    return *currentToken;
+    return currentToken;
 }
 
 /**
@@ -96,8 +94,10 @@ Token Lexer::Peek() {
  */
 Token Lexer::Next() {
     Token ret = Peek();
-    if (ret.type != TokenType::Eof) {
-        currentToken = nullptr;
+    if (ret.type == TokenType::Eof) {
+        consumedEof = true;
+    } else {
+        currentToken = scanNext();
     }
     return ret;
 }

--- a/lexer/impl/lexer.cpp
+++ b/lexer/impl/lexer.cpp
@@ -35,6 +35,7 @@ common::Trie<TokenType> g_keywordTrie{
     {"and", TokenType::And},
     {"or", TokenType::Or},
     {"xor", TokenType::Xor},
+    {"return", TokenType::Return},
 };
 
 common::Trie<TokenType> g_operatorTrie{

--- a/lexer/impl/token.cpp
+++ b/lexer/impl/token.cpp
@@ -1,0 +1,118 @@
+#include "token.hpp"
+
+namespace lexer {
+
+std::string to_string(TokenType type) {
+    switch (type) {
+    case TokenType::Illegal:
+        return "illagal token";
+    case TokenType::Eof:
+        return "end of file";
+    case TokenType::Comment:
+        return "comment";
+    case TokenType::Identifier:
+        return "identifier";
+    case TokenType::Int:
+        return "integer literal";
+    case TokenType::Real:
+        return "real literal";
+    case TokenType::Less:
+        return "'<'";
+    case TokenType::Greater:
+        return "'>'";
+    case TokenType::Eq:
+        return "'='";
+    case TokenType::Leq:
+        return "'<='";
+    case TokenType::Geq:
+        return "'>='";
+    case TokenType::Neq:
+        return "'/='";
+    case TokenType::Assign:
+        return "':='";
+    case TokenType::Add:
+        return "'+'";
+    case TokenType::Sub:
+        return "'-'";
+    case TokenType::Mul:
+        return "'*'";
+    case TokenType::Div:
+        return "'/'";
+    case TokenType::Mod:
+        return "'%'";
+    case TokenType::OpenParen:
+        return "'('";
+    case TokenType::OpenBrack:
+        return "'['";
+    case TokenType::Comma:
+        return "','";
+    case TokenType::Dot:
+        return "'.'";
+    case TokenType::TwoDots:
+        return "'..'";
+    case TokenType::CloseParen:
+        return "')'";
+    case TokenType::CloseBrack:
+        return "']'";
+    case TokenType::Semicolon:
+        return "semicolon";
+    case TokenType::Colon:
+        return "':'";
+    case TokenType::NewLine:
+        return "new line";
+    case TokenType::Var:
+        return "'var'";
+    case TokenType::Type:
+        return "'type'";
+    case TokenType::Routine:
+        return "'routine'";
+    case TokenType::Is:
+        return "'is'";
+    case TokenType::IntegerType:
+        return "'integer'";
+    case TokenType::RealType:
+        return "'real'";
+    case TokenType::Boolean:
+        return "'boolean'";
+    case TokenType::Record:
+        return "'record'";
+    case TokenType::Array:
+        return "'array'";
+    case TokenType::True:
+        return "'true'";
+    case TokenType::False:
+        return "'false'";
+    case TokenType::While:
+        return "'while'";
+    case TokenType::For:
+        return "'for'";
+    case TokenType::Loop:
+        return "'loop'";
+    case TokenType::End:
+        return "'end'";
+    case TokenType::Reverse:
+        return "'reverse'";
+    case TokenType::In:
+        return "'in'";
+    case TokenType::If:
+        return "'if'";
+    case TokenType::Then:
+        return "'then'";
+    case TokenType::Else:
+        return "'else'";
+    case TokenType::Not:
+        return "'not'";
+    case TokenType::And:
+        return "'and'";
+    case TokenType::Or:
+        return "'or'";
+    case TokenType::Xor:
+        return "'xor'";
+    case TokenType::Return:
+        return "'return'";
+    }
+
+    return "<internal error: unknown token>";
+}
+
+} // namespace lexer

--- a/lexer/impl/token.cpp
+++ b/lexer/impl/token.cpp
@@ -5,7 +5,7 @@ namespace lexer {
 std::string to_string(TokenType type) {
     switch (type) {
     case TokenType::Illegal:
-        return "illagal token";
+        return "illegal token";
     case TokenType::Eof:
         return "end of file";
     case TokenType::Comment:

--- a/lexer/lexer.hpp
+++ b/lexer/lexer.hpp
@@ -1,20 +1,19 @@
 #pragma once
 
-#include <functional>
-#include <cctype>
-#include <string_view>
-#include "trie.hpp"
 #include "token.hpp"
+#include "trie.hpp"
+#include <cctype>
+#include <functional>
+#include <string_view>
 
 namespace lexer {
-
 
 extern common::Trie<TokenType> g_keywordTrie;
 extern common::Trie<TokenType> g_operatorTrie;
 
 class Lexer {
 public:
-    Lexer(std::string_view src) : m_buf(src) {}
+    Lexer(std::string_view src) : m_buf(src) { currentToken = scanNext(); }
 
     Token Next();
 
@@ -25,23 +24,16 @@ private:
     size_t m_pos = 0;
     size_t m_lineStartPos = 0;
     size_t m_lineNum = 1;
-    std::shared_ptr<Token> currentToken = nullptr;
+    Token currentToken;
+    bool consumedEof = false;
 
-    static bool isSpace(char ch) {
-        return ch != '\n' && std::isspace(ch);
-    }
+    static bool isSpace(char ch) { return ch != '\n' && std::isspace(ch); }
 
-    static bool isDigit(char ch) {
-        return std::isdigit(ch);
-    }
+    static bool isDigit(char ch) { return std::isdigit(ch); }
 
-    static bool isIdentStart(char ch) {
-        return ch == '_' || std::isalpha(ch);
-    }
+    static bool isIdentStart(char ch) { return ch == '_' || std::isalpha(ch); }
 
-    static bool isIdentSuf(char ch) {
-        return ch == '_' || std::isalnum(ch);
-    }
+    static bool isIdentSuf(char ch) { return ch == '_' || std::isalnum(ch); }
 
     size_t skipWhile(size_t bufPos, std::function<bool(char)> pred);
 
@@ -49,6 +41,5 @@ private:
 
     char peek(size_t offset = 1);
 };
-
 
 } // namespace lexer

--- a/lexer/meson.build
+++ b/lexer/meson.build
@@ -1,6 +1,6 @@
 incdir = include_directories('.')
 liblexer = static_library('lexer', 
-                         sources : ['impl/lexer.cpp'], 
+                         sources : ['impl/lexer.cpp', 'impl/token.cpp'], 
                          cpp_args : riddle_cpp_args,
                          dependencies : [ fmt_dep, common_dep ],
                          install : true)

--- a/lexer/token.hpp
+++ b/lexer/token.hpp
@@ -89,4 +89,6 @@ struct Token {
     friend bool operator!=(const Token& a, const Token& b) { return !(a == b); }
 };
 
+std::string to_string(TokenType type);
+
 } // namespace lexer

--- a/lexer/token.hpp
+++ b/lexer/token.hpp
@@ -4,7 +4,7 @@
 
 namespace lexer {
 
-enum class TokenType{
+enum class TokenType {
     Illegal,
     Eof,
     Comment,
@@ -28,17 +28,17 @@ enum class TokenType{
     Div, // /
     Mod, // %
 
-    OpenParen,  // (
-    OpenBrack,  // [
-    Comma,   // ,
-    Dot,     // .
-    TwoDots, // ..
+    OpenParen, // (
+    OpenBrack, // [
+    Comma,     // ,
+    Dot,       // .
+    TwoDots,   // ..
 
-    CloseParen,    // )
-    CloseBrack,    // ]
-    Semicolon, // ;
-    Colon,     // :
-    NewLine,   // \n
+    CloseParen, // )
+    CloseBrack, // ]
+    Semicolon,  // ;
+    Colon,      // :
+    NewLine,    // \n
 
     // Keywords
     Var,
@@ -56,23 +56,23 @@ enum class TokenType{
     For,
     Loop,
     End,
-    Reverse, 
-    In, 
+    Reverse,
+    In,
     If,
-    Then, 
+    Then,
     Else,
     Not,
     And,
     Or,
     Xor,
+    Return,
 };
 
 struct Token {
 
-    struct Position
-    {
-        size_t line;       // starting at 1
-        size_t column;     // starting at 1, in bytes
+    struct Position {
+        size_t line;   // starting at 1
+        size_t column; // starting at 1, in bytes
         bool operator==(const Position& other) const {
             return line == other.line && column == other.column;
         }
@@ -83,17 +83,10 @@ struct Token {
     std::string lit;
 
     friend bool operator==(const Token& a, const Token& b) {
-        return a.type == b.type && 
-               a.pos == b.pos &&
-               a.lit == b.lit;
+        return a.type == b.type && a.pos == b.pos && a.lit == b.lit;
     }
 
-    friend bool operator!=(const Token& a, const Token& b) {
-        return !(a == b);
-    }
-
+    friend bool operator!=(const Token& a, const Token& b) { return !(a == b); }
 };
 
-
-
-}
+} // namespace lexer

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -623,8 +623,7 @@ sPtr<ast::Expression> Parser::parseUnaryExpression() {
         }
     } else if (isPrimary(currentToken.type)) {
         // if is pure primary
-        ast::Primary primNode;
-        primNode.begin = currentToken.pos;
+        sPtr<ast::Primary> primNode;
         currentToken = m_lexer.Next();
         // check if parametrized routine call
         if (currentToken.type == TokenType::Identifier &&
@@ -632,10 +631,35 @@ sPtr<ast::Expression> Parser::parseUnaryExpression() {
             return parseRoutineCall(currentToken);
             // TODO: if ambiguous, make an identifier
         }
-        // return Primary only
-        primNode.value = currentToken.type;
-        primNode.end = currentToken.pos;
-        return std::make_shared<ast::Primary>(primNode);
+
+        switch (currentToken.type) {
+        case TokenType::Int:
+            primNode = std::make_shared<ast::IntegerLiteral>(
+                std::stoll(currentToken.lit));
+            break;
+        case TokenType::Real:
+            primNode =
+                std::make_shared<ast::RealLiteral>(std::stod(currentToken.lit));
+            break;
+        case TokenType::True:
+            primNode = std::make_shared<ast::BooleanLiteral>(true);
+            break;
+        case TokenType::False:
+            primNode = std::make_shared<ast::BooleanLiteral>(false);
+            break;
+        case TokenType::Identifier:
+            primNode = std::make_shared<ast::Identifier>(currentToken.lit);
+            break;
+        default:
+            m_errors.push_back(Error{
+                .pos = currentToken.pos,
+                .message = "Unknown Primary expression",
+            });
+            return nullptr;
+        }
+        primNode->begin = currentToken.pos;
+        primNode->end = currentToken.pos;
+        return primNode;
     }
     return nullptr;
 }

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -18,10 +18,10 @@ sPtr<ast::Program> Parser::parseProgram() {
     while ((currentToken = m_lexer.Peek()).type != TokenType::Eof) {
         switch (currentToken.type) {
         case TokenType::Routine:
-            programNode.routines.push_back(parseRoutine());
+            programNode.routines.push_back(parseRoutineDecl());
             continue;
         case TokenType::Var:
-            programNode.variables.push_back(parseVariable());
+            programNode.variables.push_back(parseVariableDecl());
             continue;
         case TokenType::Type:
             programNode.types.push_back(parseType());
@@ -41,8 +41,8 @@ sPtr<ast::Program> Parser::parseProgram() {
     return std::make_shared<ast::Program>(programNode);
 }
 
-sPtr<ast::Routine> Parser::parseRoutine() {
-    ast::Routine routineNode;
+sPtr<ast::RoutineDecl> Parser::parseRoutineDecl() {
+    ast::RoutineDecl routineNode;
     Token currentToken = skipWhile(isNewLine);
     if (currentToken.type != TokenType::Routine) {
         m_errors.push_back(Error{
@@ -131,7 +131,7 @@ sPtr<ast::Routine> Parser::parseRoutine() {
             ;
         return nullptr;
     }
-    return std::make_shared<ast::Routine>(routineNode);
+    return std::make_shared<ast::RoutineDecl>(routineNode);
 }
 
 sPtr<ast::Parameter> Parser::parseParameter() {
@@ -232,7 +232,7 @@ sPtr<ast::RecordType> Parser::parseRecordType() {
     while (m_lexer.Peek().type == TokenType::NewLine)
         m_lexer.Next();
     while (m_lexer.Peek().type != TokenType::End) {
-        recordNode.fields.push_back(parseVariable());
+        recordNode.fields.push_back(parseVariableDecl());
         while (m_lexer.Peek().type == TokenType::NewLine)
             m_lexer.Next();
     }
@@ -240,7 +240,7 @@ sPtr<ast::RecordType> Parser::parseRecordType() {
     return std::make_shared<ast::RecordType>(recordNode);
 }
 
-sPtr<ast::Variable> Parser::parseVariable() {
+sPtr<ast::VariableDecl> Parser::parseVariableDecl() {
     Token token = skipWhile(isNewLine);
     if (token.type != TokenType::Var) {
         m_errors.push_back(Error{
@@ -257,7 +257,7 @@ sPtr<ast::Variable> Parser::parseVariable() {
         });
         return nullptr;
     }
-    ast::Variable variable;
+    ast::VariableDecl variable;
     variable.name = token;
     token = skipWhile(isNewLine);
     if (token.type != TokenType::Is && token.type != TokenType::Colon) {
@@ -284,7 +284,7 @@ sPtr<ast::Variable> Parser::parseVariable() {
         });
         return nullptr;
     }
-    return std::make_shared<ast::Variable>(variable);
+    return std::make_shared<ast::VariableDecl>(variable);
 }
 
 sPtr<ast::Body> Parser::parseBody() {
@@ -293,7 +293,7 @@ sPtr<ast::Body> Parser::parseBody() {
     while ((currentToken = m_lexer.Peek()).type != TokenType::End) {
         switch (currentToken.type) {
         case TokenType::Var:
-            body.variables.push_back(parseVariable());
+            body.variables.push_back(parseVariableDecl());
             break;
         case TokenType::Type:
             body.types.push_back(parseType());

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -623,13 +623,12 @@ sPtr<ast::Expression> Parser::parseUnaryExpression() {
         }
     } else if (isPrimary(currentToken.type)) {
         // if is pure primary
-        sPtr<ast::Primary> primNode;
+        sPtr<ast::Expression> primNode;
         currentToken = m_lexer.Next();
         // check if parametrized routine call
         if (currentToken.type == TokenType::Identifier &&
             m_lexer.Peek().type == TokenType::OpenParen) {
             return parseRoutineCall(currentToken);
-            // TODO: if ambiguous, make an identifier
         }
 
         switch (currentToken.type) {
@@ -647,7 +646,7 @@ sPtr<ast::Expression> Parser::parseUnaryExpression() {
         case TokenType::False:
             primNode = std::make_shared<ast::BooleanLiteral>(false);
             break;
-        case TokenType::Identifier:
+        case TokenType::Identifier: // can possibly be a routine call
             primNode = std::make_shared<ast::Identifier>(currentToken.lit);
             break;
         default:

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -18,8 +18,8 @@ static const std::array<TokenType, 3> primitives{
 namespace util {
 
 
-inline bool IsPrimitiveType(TokenType type) {
-    return std::count(primitives.begin(), primitives.end(), type) != 0;
+inline bool HasPrimitiveType(Token tok) {
+    return std::count(primitives.begin(), primitives.end(), tok.type) != 0;
 }
 
 template <typename Container, typename T>
@@ -236,7 +236,7 @@ sPtr<ast::TypeDecl> Parser::parseTypeDecl() {
 sPtr<ast::Type> Parser::parseType() {
     Token currentToken = m_lexer.Peek();
 
-    if (util::IsPrimitiveType(currentToken.type)) {
+    if (util::HasPrimitiveType(currentToken)) {
         sPtr<ast::PrimitiveType> typeNode;
         switch (currentToken.type) {
         case TokenType::IntegerType:

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -22,6 +22,13 @@ inline bool IsPrimitiveType(TokenType type) {
     return std::count(primitives.begin(), primitives.end(), type) != 0;
 }
 
+template <typename Container, typename T>
+inline auto Contains(const Container& data,
+                     const T& value)
+                    -> decltype(std::end(data), true) {
+    return std::end(data) != std::find(std::begin(data), std::end(data), value);
+}
+
 
 }
 
@@ -785,18 +792,19 @@ Token Parser::expect(const std::vector<TokenType>& types,
                      const std::string& err_msg) {
     // if "new line" is not one of the characters we are looking for, then skip
     // any occurence of it
-    if (std::find(types.begin(), types.end(), TokenType::NewLine) ==
-        types.end()) {
+    if (!util::Contains(types, TokenType::NewLine)) {
         skipWhitespace();
     }
+
     Token next = m_lexer.Next();
-    if (std::find(types.begin(), types.end(), next.type) == types.end()) {
+    if (!util::Contains(types, next.type)) {
         m_errors.push_back(Error{
             .pos = next.pos,
             .message = err_msg,
         });
         return Token{.type = TokenType::Illegal};
     }
+
     return next;
 }
 
@@ -820,8 +828,7 @@ void Parser::skipWhitespace() {
  */
 void Parser::advance(const std::vector<TokenType>& types) {
     Token next = m_lexer.Next();
-    while (next.type != TokenType::Eof &&
-           std::find(types.begin(), types.end(), next.type) == types.end()) {
+    while (next.type != TokenType::Eof && !util::Contains(types, next.type)) {
         next = m_lexer.Next();
     }
 }

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -1,17 +1,29 @@
-#include "parser.hpp"
-#include "token.hpp"
+#include <algorithm>
 #include <memory>
+#include "token.hpp"
+
+#include "parser.hpp"
 
 namespace parser {
 
 using lexer::Token;
 using lexer::TokenType;
 
-static std::array<TokenType, 3> primitives{
+static const std::array<TokenType, 3> primitives{
     TokenType::IntegerType,
     TokenType::RealType,
     TokenType::Boolean,
 };
+
+namespace util {
+
+
+inline bool IsPrimitiveType(TokenType type) {
+    return std::count(primitives.begin(), primitives.end(), type) != 0;
+}
+
+
+}
 
 sPtr<ast::Program> Parser::parseProgram() {
     ast::Program programNode;
@@ -179,9 +191,8 @@ sPtr<ast::TypeDecl> Parser::parseTypeDecl() {
 
 sPtr<ast::Type> Parser::parseType() {
     Token currentToken = m_lexer.Peek();
-    if (TokenType* type = std::find(std::begin(primitives),
-                                    std::end(primitives), currentToken.type);
-        type != std::end(primitives)) {
+
+    if (util::IsPrimitiveType(currentToken.type)) {
         sPtr<ast::PrimitiveType> typeNode;
         switch (currentToken.type) {
         case TokenType::IntegerType:

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -145,24 +145,16 @@ sPtr<ast::RoutineDecl> Parser::parseRoutineDecl() {
 
 sPtr<ast::Parameter> Parser::parseParameter() {
     expect(TokenType::Identifier);
-
-    if (m_current.type == TokenType::Illegal) {
-        advance({TokenType::CloseParen, TokenType::Comma, TokenType::NewLine});
-        return nullptr;
-    }
+    ADVANCE_ON_FAIL({TokenType::CloseParen, TokenType::Comma, TokenType::NewLine});
 
     ast::Parameter parameterNode;
     parameterNode.begin = m_current.pos;
     parameterNode.name = m_current.lit;
 
     expect(TokenType::Colon);
-
-    if (m_current.type == TokenType::Illegal) {
-        // Note: the following is not correct as it will consume the ) or ,
-        //  token expected by `parseRoutineDecl`. A better alternative is needed
-        advance({TokenType::CloseParen, TokenType::Comma, TokenType::NewLine});
-        return nullptr;
-    }
+    // Note: the following is not correct as it will consume the ) or ,
+    //  token expected by `parseRoutineDecl`. A better alternative is needed
+    ADVANCE_ON_FAIL({TokenType::CloseParen, TokenType::Comma, TokenType::NewLine});
 
     parameterNode.type = parseType();
 
@@ -251,10 +243,7 @@ sPtr<ast::ArrayType> Parser::parseArrayType() {
         m_lexer.Next();
         arrayNode.length = parseExpression();
         expect(TokenType::CloseBrack);
-        if (m_current.type == TokenType::Illegal) {
-            advance(TokenType::CloseBrack);
-            return nullptr;
-        }
+        ADVANCE_ON_FAIL(TokenType::CloseBrack);
     }
 
     skipWhitespace();

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -38,9 +38,7 @@ sPtr<ast::Program> Parser::parseProgram() {
                 .pos = currentToken.pos,
                 .message = "Unexpected token.",
             });
-            while (m_lexer.Peek().type != TokenType::NewLine &&
-                   m_lexer.Peek().type != TokenType::Eof)
-                m_lexer.Next();
+            advance(TokenType::NewLine);
         }
         if (currentToken.type != TokenType::Eof) {
             currentToken = m_lexer.Peek();

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -78,7 +78,7 @@ sPtr<ast::Program> Parser::parseProgram() {
         case TokenType::Eof:
             break;
         default:
-            error(m_current, "unexpected token");
+            error("unexpected token");
             advance(TokenType::NewLine);
         }
         if (m_current.type != TokenType::Eof) {
@@ -206,7 +206,7 @@ sPtr<ast::Type> Parser::parseType() {
             typeNode = std::make_shared<ast::BooleanType>();
             break;
         default:
-            error(m_current, "unknown primitive type");
+            error("unknown primitive type");
             return nullptr;
         }
         typeNode->begin = m_current.pos;
@@ -225,7 +225,7 @@ sPtr<ast::Type> Parser::parseType() {
         typeNode.end = m_current.pos;
         return std::make_shared<ast::AliasedType>(typeNode);
     } else {
-        error(m_current, "unknown type");
+        error("unknown type");
         m_lexer.Next();
         return nullptr;
     }
@@ -352,7 +352,7 @@ sPtr<ast::Statement> Parser::parseStatement() {
         //  a routine call or a variable name.
         auto primaryNode = std::dynamic_pointer_cast<ast::Primary>(expression);
         if (primaryNode == nullptr) {
-            error(m_current, "invalid token, expected a routine call");
+            error("invalid token, expected a routine call");
             return nullptr;
         }
 
@@ -370,7 +370,7 @@ sPtr<ast::Statement> Parser::parseStatement() {
     case TokenType::Return:
         return parseReturnStatement();
     default:
-        error(m_current, "unexpected token");
+        error("unexpected token");
         advance(TokenType::NewLine);
         return nullptr;
     }
@@ -560,7 +560,7 @@ sPtr<ast::Expression> Parser::parseUnaryExpression() {
             return exprNode;
         }
 
-        error(m_current, "expected unary operator");
+        error("expected unary operator");
         return nullptr;
 
     } else if (isPrimary(m_current.type)) {
@@ -593,7 +593,7 @@ sPtr<ast::Expression> Parser::parseUnaryExpression() {
             primNode = std::make_shared<ast::Identifier>(m_current.lit);
             break;
         default:
-            error(m_current, "unknown primary expression");
+            error("unknown primary expression");
             return nullptr;
         }
 
@@ -775,6 +775,13 @@ void Parser::advance(const std::vector<TokenType>& types) {
  */
 void Parser::advance(const TokenType& type) {
     return advance(std::vector{type});
+}
+
+void Parser::error(const std::string& msg) {
+    m_errors.push_back(Error{
+        .pos = m_current.pos,
+        .message = msg,
+    });
 }
 
 void Parser::error(const lexer::Token& tok, const std::string& msg) {

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -64,7 +64,7 @@ sPtr<ast::RoutineDecl> Parser::parseRoutineDecl() {
         advance(TokenType::End);
         return nullptr;
     }
-    routineNode.name = currentToken;
+    routineNode.name = currentToken.lit;
 
     if (expect(TokenType::OpenParen, "Expected to find '('.").type ==
         TokenType::Illegal) {
@@ -128,7 +128,7 @@ sPtr<ast::Parameter> Parser::parseParameter() {
         return nullptr;
     }
     parameterNode.begin = currentToken.pos;
-    parameterNode.name = currentToken;
+    parameterNode.name = currentToken.lit;
 
     currentToken = expect(TokenType::Colon, "Expected to find a ':'.");
     if (currentToken.type == TokenType::Illegal) {
@@ -186,7 +186,7 @@ sPtr<ast::Type> Parser::parseType() {
         type != std::end(primitives)) {
         ast::PrimitiveType typeNode;
         typeNode.begin = currentToken.pos;
-        typeNode.type = currentToken;
+        typeNode.type = currentToken.type;
         currentToken = m_lexer.Next();
         typeNode.end = currentToken.pos;
         return std::make_shared<ast::PrimitiveType>(typeNode);
@@ -197,7 +197,7 @@ sPtr<ast::Type> Parser::parseType() {
     } else if (currentToken.type == TokenType::Identifier) {
         ast::AliasedType typeNode;
         typeNode.begin = currentToken.pos;
-        typeNode.name = currentToken;
+        typeNode.name = currentToken.lit;
         currentToken = m_lexer.Next();
         typeNode.end = currentToken.pos;
         return std::make_shared<ast::AliasedType>(typeNode);
@@ -273,7 +273,7 @@ sPtr<ast::VariableDecl> Parser::parseVariableDecl() {
         advance({TokenType::Semicolon, TokenType::NewLine});
         return nullptr;
     }
-    variableNode.name = currentToken;
+    variableNode.name = currentToken.lit;
 
     currentToken =
         expect({TokenType::Colon, TokenType::Is},
@@ -450,7 +450,7 @@ sPtr<ast::ForLoop> Parser::parseForLoop() {
         advance(TokenType::End);
         return nullptr;
     }
-    forNode.loopVar = currentToken;
+    forNode.loopVar = currentToken.lit;
 
     currentToken =
         expect(TokenType::In, "Expected \"in\" keyword but didn't find it.");
@@ -580,7 +580,7 @@ sPtr<ast::Expression> Parser::parseUnaryExpression() {
             ast::UnaryExpression exprNode;
             exprNode.begin = currentToken.pos;
             currentToken = m_lexer.Next();
-            exprNode.operation = currentToken;
+            exprNode.operation = currentToken.type;
             exprNode.operand = parseUnaryExpression();
             if (exprNode.operand != nullptr) {
                 exprNode.end = exprNode.operand->end;
@@ -617,7 +617,7 @@ sPtr<ast::Expression> Parser::parseUnaryExpression() {
             // TODO: if ambiguous, make an identifier
         }
         // return Primary only
-        primNode.value = currentToken;
+        primNode.value = currentToken.type;
         primNode.end = currentToken.pos;
         return std::make_shared<ast::Primary>(primNode);
     }
@@ -642,7 +642,7 @@ sPtr<ast::Expression> Parser::parseBinaryExpression(int prec1) {
             expr.begin = lhs->begin;
         }
         expr.operand1 = lhs;
-        expr.operation = op;
+        expr.operation = op.type;
 
         if (op.type == TokenType::OpenBrack) {
             expr.operand2 = parseBinaryExpression(0);
@@ -663,7 +663,7 @@ sPtr<ast::Expression> Parser::parseBinaryExpression(int prec1) {
 
 sPtr<ast::RoutineCall> Parser::parseRoutineCall(Token routineName) {
     ast::RoutineCall rountineCallNode;
-    rountineCallNode.routine = routineName; // save the function name
+    rountineCallNode.routineName = routineName.lit; // save the function name
     rountineCallNode.begin = routineName.pos;
 
     Token currentToken = m_lexer.Peek();

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -7,9 +7,10 @@ namespace parser {
 using lexer::Token;
 using lexer::TokenType;
 
-static std::array<TokenType, 2> primitives{
+static std::array<TokenType, 3> primitives{
     TokenType::IntegerType,
     TokenType::RealType,
+    TokenType::Boolean,
 };
 
 sPtr<ast::Program> Parser::parseProgram() {

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -704,7 +704,7 @@ sPtr<ast::RoutineCall> Parser::parseRoutineCall(Token routineName) {
     return std::make_shared<ast::RoutineCall>(rountineCallNode);
 }
 
-int Parser::opPrec(TokenType token) {
+int Parser::opPrec(const TokenType& token) {
     switch (token) {
     case TokenType::Or:  // or
     case TokenType::Xor: // xor
@@ -737,7 +737,7 @@ int Parser::opPrec(TokenType token) {
     }
 }
 
-bool Parser::isPrimary(TokenType token) {
+bool Parser::isPrimary(const TokenType& token) {
     return token == TokenType::Identifier || token == TokenType::Int ||
            token == TokenType::Real || token == TokenType::True ||
            token == TokenType::False;
@@ -749,7 +749,8 @@ bool Parser::isPrimary(TokenType token) {
  * token. The next token is consumed (along with any whitespace before it)
  * regardless of whether or not it was a desired token.
  */
-Token Parser::expect(std::vector<TokenType> types, std::string err_msg) {
+Token Parser::expect(const std::vector<TokenType>& types,
+                     const std::string& err_msg) {
     // if "new line" is not one of the characters we are looking for, then skip
     // any occurence of it
     if (std::find(types.begin(), types.end(), TokenType::NewLine) ==
@@ -771,7 +772,7 @@ Token Parser::expect(std::vector<TokenType> types, std::string err_msg) {
  * An overload of `expect` that allows passing just one type for ease of use.
  * Wraps that token type in a vector
  */
-Token Parser::expect(TokenType type, std::string err_msg) {
+Token Parser::expect(const TokenType& type, const std::string& err_msg) {
     return expect(std::vector{type}, err_msg);
 }
 
@@ -785,7 +786,7 @@ void Parser::skipWhitespace() {
  * Keeps consuming tokens until it finds one of the desired token types, and
  *  consumes that one as well.
  */
-void Parser::advance(std::vector<TokenType> types) {
+void Parser::advance(const std::vector<TokenType>& types) {
     Token next = m_lexer.Next();
     while (next.type != TokenType::Eof &&
            std::find(types.begin(), types.end(), next.type) == types.end()) {
@@ -797,7 +798,9 @@ void Parser::advance(std::vector<TokenType> types) {
  * An overload of `advance` that allows passing just one type for ease of use.
  * Wraps that token type in a vector.
  */
-void Parser::advance(TokenType type) { return advance(std::vector{type}); }
+void Parser::advance(const TokenType& type) {
+    return advance(std::vector{type});
+}
 
 std::vector<parser::Error> Parser::getErrors() { return m_errors; }
 

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -107,7 +107,6 @@ sPtr<ast::RoutineDecl> Parser::parseRoutineDecl() {
         return nullptr;
     }
     if (currentToken.type == TokenType::Colon) {
-        currentToken = skipWhile(isNewLine);
         routineNode.returnType = parseType();
     }
     currentToken = skipWhile(isNewLine);

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -47,7 +47,7 @@ std::string GenExpectMessage(const std::vector<TokenType>& types) {
     }
 
     std::string msg = "expected ";
-    for (int i = 0; i < types.size() - 1; i++) {
+    for (int i = 0; i < (int)types.size() - 1; i++) {
         msg += lexer::to_string(types[i]) + ", ";
     }
 
@@ -546,6 +546,7 @@ sPtr<ast::Expression> Parser::parseUnaryExpression() {
             }
 
             return std::make_shared<ast::UnaryExpression>(exprNode);
+
         } else if (m_current.type == TokenType::OpenParen) {
             skipWhitespace();
             // parenthesis -> more priority
@@ -557,10 +558,11 @@ sPtr<ast::Expression> Parser::parseUnaryExpression() {
             ADVANCE_ON_FAIL(TokenType::CloseParen);
 
             return exprNode;
-        } else {
-            error(m_current, "expected unary operator");
-            return nullptr;
         }
+
+        error(m_current, "expected unary operator");
+        return nullptr;
+
     } else if (isPrimary(m_current.type)) {
         // if is pure primary
         next();
@@ -653,6 +655,7 @@ sPtr<ast::RoutineCall> Parser::parseRoutineCall(Token routineName) {
         if (m_current.type == TokenType::CloseParen) {
             m_lexer.Next(); // consume the ')'
         }
+
         while (m_current.type != TokenType::CloseParen) {
             rountineCallNode.args.push_back(parseExpression());
 

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -184,12 +184,28 @@ sPtr<ast::Type> Parser::parseType() {
     if (TokenType* type = std::find(std::begin(primitives),
                                     std::end(primitives), currentToken.type);
         type != std::end(primitives)) {
-        ast::PrimitiveType typeNode;
-        typeNode.begin = currentToken.pos;
-        typeNode.type = currentToken.type;
+        sPtr<ast::PrimitiveType> typeNode;
+        switch (currentToken.type) {
+        case TokenType::IntegerType:
+            typeNode = std::make_shared<ast::IntegerType>();
+            break;
+        case TokenType::RealType:
+            typeNode = std::make_shared<ast::RealType>();
+            break;
+        case TokenType::Boolean:
+            typeNode = std::make_shared<ast::BooleanType>();
+            break;
+        default:
+            m_errors.push_back(Error{
+                .pos = currentToken.pos,
+                .message = "Unknown primitive type",
+            });
+            return nullptr;
+        }
+        typeNode->begin = currentToken.pos;
         currentToken = m_lexer.Next();
-        typeNode.end = currentToken.pos;
-        return std::make_shared<ast::PrimitiveType>(typeNode);
+        typeNode->end = currentToken.pos;
+        return typeNode;
     } else if (currentToken.type == TokenType::Array) {
         return parseArrayType();
     } else if (currentToken.type == TokenType::Record) {

--- a/parser/impl/parser.cpp
+++ b/parser/impl/parser.cpp
@@ -7,8 +7,6 @@ namespace parser {
 using lexer::Token;
 using lexer::TokenType;
 
-// ---- @kureduro
-
 static std::array<TokenType, 2> primitives{
     TokenType::IntegerType,
     TokenType::RealType,
@@ -242,8 +240,6 @@ sPtr<ast::RecordType> Parser::parseRecordType() {
     return std::make_shared<ast::RecordType>(recordNode);
 }
 
-// ---- @CrazyDream1
-
 sPtr<ast::Variable> Parser::parseVariable() {
     Token token = skipWhile(isNewLine);
     if (token.type != TokenType::Var) {
@@ -354,8 +350,6 @@ sPtr<ast::Assignment> Parser::parseAssignment(sPtr<ast::Expression> left) {
     assignment.rhs = parseExpression();
     return std::make_shared<ast::Assignment>(assignment);
 }
-
-// ---- @MefAldemisov
 
 sPtr<ast::WhileLoop> Parser::parseWhileLoop() {
     // condition: Expr
@@ -559,8 +553,6 @@ sPtr<ast::IfStatement> Parser::parseIfStatement() {
     return std::make_shared<ast::IfStatement>(ifNode);
 }
 
-// ---- @aabounegm
-
 sPtr<ast::Expression> Parser::parseExpression() {
     return parseBinaryExpression();
 }
@@ -684,8 +676,6 @@ sPtr<ast::RoutineCall> Parser::parseRoutineCall(Token routineName) {
     t = m_lexer.Next(); // read ')'
     return std::make_shared<ast::RoutineCall>(rc);
 }
-
-// ---- End separation
 
 bool Parser::isNewLine(Token tok) { return tok.type == TokenType::NewLine; }
 

--- a/parser/parser.hpp
+++ b/parser/parser.hpp
@@ -33,6 +33,7 @@ public:
     sPtr<ast::WhileLoop> parseWhileLoop();
     sPtr<ast::ForLoop> parseForLoop();
     sPtr<ast::IfStatement> parseIfStatement();
+    sPtr<ast::ReturnStatement> parseReturnStatement();
     sPtr<ast::Expression> parseExpression();
     sPtr<ast::Expression> parseUnaryExpression();
     sPtr<ast::Expression> parseBinaryExpression(int prec1 = 0);

--- a/parser/parser.hpp
+++ b/parser/parser.hpp
@@ -53,6 +53,7 @@ private:
     void skipWhitespace();
     void advance(const std::vector<lexer::TokenType>&);
     void advance(const lexer::TokenType&);
+    void error(const std::string& msg);
     void error(const lexer::Token& pos, const std::string& msg);
     bool isPrimary(const lexer::TokenType&);
     int opPrec(const lexer::TokenType&);

--- a/parser/parser.hpp
+++ b/parser/parser.hpp
@@ -41,10 +41,8 @@ public:
 private:
     lexer::Lexer m_lexer;
     std::vector<Error> m_errors;
-    lexer::Token expect(const std::vector<lexer::TokenType>&,
-                        const std::string& = "Unexpected Token.");
-    lexer::Token expect(const lexer::TokenType&,
-                        const std::string& = "Unexpected Token.");
+    lexer::Token expect(const std::vector<lexer::TokenType>&, std::string = "");
+    lexer::Token expect(const lexer::TokenType&, std::string = "");
     void skipWhitespace();
     void advance(const std::vector<lexer::TokenType>&);
     void advance(const lexer::TokenType&);

--- a/parser/parser.hpp
+++ b/parser/parser.hpp
@@ -41,14 +41,15 @@ public:
 private:
     lexer::Lexer m_lexer;
     std::vector<Error> m_errors;
-    lexer::Token expect(std::vector<lexer::TokenType>,
-                        std::string = "Unexpected Token.");
-    lexer::Token expect(lexer::TokenType, std::string = "Unexpected Token.");
+    lexer::Token expect(const std::vector<lexer::TokenType>&,
+                        const std::string& = "Unexpected Token.");
+    lexer::Token expect(const lexer::TokenType&,
+                        const std::string& = "Unexpected Token.");
     void skipWhitespace();
-    void advance(std::vector<lexer::TokenType>);
-    void advance(lexer::TokenType);
-    bool isPrimary(lexer::TokenType);
-    int opPrec(lexer::TokenType);
+    void advance(const std::vector<lexer::TokenType>&);
+    void advance(const lexer::TokenType&);
+    bool isPrimary(const lexer::TokenType&);
+    int opPrec(const lexer::TokenType&);
 };
 
 } // namespace parser

--- a/parser/parser.hpp
+++ b/parser/parser.hpp
@@ -40,9 +40,16 @@ public:
 
 private:
     lexer::Lexer m_lexer;
+    lexer::Token m_current;
+
     std::vector<Error> m_errors;
-    lexer::Token expect(const std::vector<lexer::TokenType>&, std::string = "");
-    lexer::Token expect(const lexer::TokenType&, std::string = "");
+
+
+    void expect(const std::vector<lexer::TokenType>&, std::string = "");
+    void expect(const lexer::TokenType&, std::string = "");
+    void next();
+    void peek();
+
     void skipWhitespace();
     void advance(const std::vector<lexer::TokenType>&);
     void advance(const lexer::TokenType&);

--- a/parser/parser.hpp
+++ b/parser/parser.hpp
@@ -20,13 +20,13 @@ class Parser {
 public:
     Parser(lexer::Lexer lexer) : m_lexer(lexer) {}
     sPtr<ast::Program> parseProgram();
-    sPtr<ast::Routine> parseRoutine();
+    sPtr<ast::RoutineDecl> parseRoutineDecl();
     sPtr<ast::Parameter> parseParameter();
     sPtr<ast::Type> parseType();
     sPtr<ast::PrimitiveType> parsePrimitiveType();
     sPtr<ast::ArrayType> parseArrayType();
     sPtr<ast::RecordType> parseRecordType();
-    sPtr<ast::Variable> parseVariable();
+    sPtr<ast::VariableDecl> parseVariableDecl();
     sPtr<ast::Body> parseBody();
     sPtr<ast::Statement> parseStatement();
     sPtr<ast::Assignment> parseAssignment(sPtr<ast::Expression> left);

--- a/parser/parser.hpp
+++ b/parser/parser.hpp
@@ -22,6 +22,7 @@ public:
     sPtr<ast::Program> parseProgram();
     sPtr<ast::RoutineDecl> parseRoutineDecl();
     sPtr<ast::Parameter> parseParameter();
+    sPtr<ast::TypeDecl> parseTypeDecl();
     sPtr<ast::Type> parseType();
     sPtr<ast::PrimitiveType> parsePrimitiveType();
     sPtr<ast::ArrayType> parseArrayType();

--- a/parser/parser.hpp
+++ b/parser/parser.hpp
@@ -48,6 +48,7 @@ private:
     void skipWhitespace();
     void advance(const std::vector<lexer::TokenType>&);
     void advance(const lexer::TokenType&);
+    void error(const lexer::Token& pos, const std::string& msg);
     bool isPrimary(const lexer::TokenType&);
     int opPrec(const lexer::TokenType&);
 };

--- a/parser/parser.hpp
+++ b/parser/parser.hpp
@@ -8,13 +8,10 @@ namespace parser {
 
 template <typename T> using sPtr = std::shared_ptr<T>;
 
-// TODO: define function to use this struct, that also advances
 struct Error {
     lexer::Token::Position pos;
     std::string message;
 };
-
-// TODO: define a type for the "context"
 
 class Parser {
 public:
@@ -44,8 +41,12 @@ public:
 private:
     lexer::Lexer m_lexer;
     std::vector<Error> m_errors;
-    lexer::Token skipWhile(std::function<bool(lexer::Token)>);
-    static bool isNewLine(lexer::Token);
+    lexer::Token expect(std::vector<lexer::TokenType>,
+                        std::string = "Unexpected Token.");
+    lexer::Token expect(lexer::TokenType, std::string = "Unexpected Token.");
+    void skipWhitespace();
+    void advance(std::vector<lexer::TokenType>);
+    void advance(lexer::TokenType);
     bool isPrimary(lexer::TokenType);
     int opPrec(lexer::TokenType);
 };

--- a/tests/parser/parser_test.cpp
+++ b/tests/parser/parser_test.cpp
@@ -164,10 +164,10 @@ SCENARIO("Parser builds a tree from tokens") {
             };
 
             ast::Parameter expected;
-            expected.name = lx[0];
+            expected.name = lx[0].lit;
             ast::ArrayType expectedType;
             ast::PrimitiveType integer;
-            integer.type = lx[3];
+            integer.type = lx[3].type;
             expectedType.elementType =
                 std::make_shared<ast::PrimitiveType>(integer);
             expected.type = std::make_shared<ast::ArrayType>(expectedType);

--- a/tests/parser/parser_test.cpp
+++ b/tests/parser/parser_test.cpp
@@ -166,10 +166,9 @@ SCENARIO("Parser builds a tree from tokens") {
             ast::Parameter expected;
             expected.name = lx[0].lit;
             ast::ArrayType expectedType;
-            ast::PrimitiveType integer;
-            integer.type = lx[3].type;
+            ast::IntegerType integer;
             expectedType.elementType =
-                std::make_shared<ast::PrimitiveType>(integer);
+                std::make_shared<ast::IntegerType>(integer);
             expected.type = std::make_shared<ast::ArrayType>(expectedType);
 
             THEN("It is parsed correctly") {


### PR DESCRIPTION
General refactoring for the parser in preparation for code generation, as agreed upon in the last meeting.
Notable changes:
- Improvements in error reporting in parser_demo
- Unify functions that skip over (or expect) specific tokens.
- Bring more consistency in code style (and error messages)
- Add required node types
- Remove dependency on lexer data structures